### PR TITLE
Fix default system prompt

### DIFF
--- a/cmdgpt.cpp
+++ b/cmdgpt.cpp
@@ -40,7 +40,7 @@ using json = nlohmann::json;
 
 // Preprocessor defines for constants
 #define DEFAULT_MODEL "gpt-4"
-#define DEFAULT_SYSTEM_PROMPT "You are a helpfull assitant!"
+#define DEFAULT_SYSTEM_PROMPT "You are a helpful assistant!"
 #define DEFAULT_LOG_LEVEL spdlog::level::warn
 #define AUTHORIZATION_HEADER "Authorization"
 #define CONTENT_TYPE_HEADER "Content-Type"


### PR DESCRIPTION
## Summary
- fix typo in default system prompt and make it read "You are a helpful assistant!"

## Testing
- `grep -R "helpfull" -n || true`