### PR TITLE
Add tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,14 @@ set(SPDLOG_BUILD_TESTING OFF)
 # Fetch the declared content. This will download the dependencies if they are not already present.
 FetchContent_MakeAvailable(httplib json spdlog)
 
+# Catch2 for unit tests
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.4.0
+)
+FetchContent_MakeAvailable(Catch2)
+
 # We need OpenSSL... 
 find_package(OpenSSL REQUIRED)
 if(OPENSSL_FOUND)
@@ -55,4 +63,11 @@ target_include_directories(cmdgpt PRIVATE ${httplib_SOURCE_DIR} ${json_SOURCE_DI
 # Link the json library and OpenSSL to the cmdgpt target
 # The nlohmann_json::nlohmann_json target brings in include paths and dependencies automatically
 target_link_libraries(cmdgpt PRIVATE nlohmann_json::nlohmann_json spdlog ${OPENSSL_LIBRARIES})
+
+enable_testing()
+
+add_executable(cmdgpt_tests tests/cmdgpt_tests.cpp)
+target_include_directories(cmdgpt_tests PRIVATE ${httplib_SOURCE_DIR} ${json_SOURCE_DIR}/include ${spdlog_SOURCE_DIR}/include)
+target_link_libraries(cmdgpt_tests PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json spdlog)
+add_test(NAME cmdgpt_tests COMMAND cmdgpt_tests)
 

--- a/README.md
+++ b/README.md
@@ -75,3 +75,14 @@ The tool utilizes the following exit status codes:
 ## Note
 
 Please note that the `-L` option and the `CMDGPT_LOG_LEVEL` environment variable expect a log level in uppercase. If an invalid log level is provided, the default log level (WARN) will be used.
+
+## Running Tests
+
+This project uses Catch2 and CTest for unit tests. To run the test suite locally:
+
+```sh
+mkdir -p build
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build --output-on-failure
+```

--- a/tests/cmdgpt_tests.cpp
+++ b/tests/cmdgpt_tests.cpp
@@ -1,0 +1,26 @@
+#include "catch2/catch.hpp"
+#include "cmdgpt.cpp"
+
+TEST_CASE("get_gpt_chat_response parses response", "[get_gpt_chat_response]") {
+    std::string output;
+    auto stub = [](const std::string&, const httplib::Headers&, const std::string&, const char*) {
+        auto r = std::make_shared<httplib::Response>();
+        r->status = HTTP_OK;
+        r->body = R"({"choices":[{"finish_reason":"stop","message":{"content":"Hi"}}]})";
+        return r;
+    };
+    int status = get_gpt_chat_response("hello", output, "key", "sys", DEFAULT_MODEL, stub);
+    REQUIRE(status == HTTP_OK);
+    REQUIRE(output == "Hi");
+}
+
+TEST_CASE("get_gpt_chat_response throws without key", "[get_gpt_chat_response]") {
+    std::string output;
+    auto stub = [](const std::string&, const httplib::Headers&, const std::string&, const char*) {
+        auto r = std::make_shared<httplib::Response>();
+        r->status = HTTP_OK;
+        r->body = "{}";
+        return r;
+    };
+    REQUIRE_THROWS_AS(get_gpt_chat_response("hello", output, "", "sys", DEFAULT_MODEL, stub), std::invalid_argument);
+}


### PR DESCRIPTION
## Summary
- add Catch2-based unit tests with stubbed HTTP calls
- document how to run the tests locally
- add GitHub Actions workflow for build and test
- allow injecting custom POST callback for easier testing

## Testing
- `cmake -S . -B build` *(fails: Failed to clone repository)*
- `ctest --test-dir build --output-on-failure` *(fails: No tests were found)*
