### PR TITLE
Create library header and integrate tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,13 +31,19 @@ FetchContent_Declare(
   GIT_TAG master
 )
 
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.4.0
+)
+
 # Setting the policy to NEW will cause the option() command in spdlog's CMakeLists.txt
 # to do nothing when SPDLOG_BUILD_TESTING is already set
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 # Don't build the test suite for SPDLOG
 set(SPDLOG_BUILD_TESTING OFF)
 # Fetch the declared content. This will download the dependencies if they are not already present.
-FetchContent_MakeAvailable(httplib json spdlog)
+FetchContent_MakeAvailable(httplib json spdlog Catch2)
 
 # We need OpenSSL... 
 find_package(OpenSSL REQUIRED)
@@ -46,13 +52,15 @@ if(OPENSSL_FOUND)
     include_directories(${OPENSSL_INCLUDE_DIR})
 endif()
 
-# Add the cmdgpt executable and its source files
-add_executable(cmdgpt cmdgpt.cpp)
+add_library(cmdgpt_lib STATIC cmdgpt.cpp)
+target_include_directories(cmdgpt_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${httplib_SOURCE_DIR} ${json_SOURCE_DIR}/include ${spdlog_SOURCE_DIR}/include)
+target_link_libraries(cmdgpt_lib PUBLIC nlohmann_json::nlohmann_json spdlog ${OPENSSL_LIBRARIES})
 
-# Since httplib and json are header-only libraries, we only need to add their directories to the include directories
-target_include_directories(cmdgpt PRIVATE ${httplib_SOURCE_DIR} ${json_SOURCE_DIR}/include ${spdlog_SOURCE_DIR}/include)
+add_executable(cmdgpt main.cpp)
+target_link_libraries(cmdgpt PRIVATE cmdgpt_lib)
 
-# Link the json library and OpenSSL to the cmdgpt target
-# The nlohmann_json::nlohmann_json target brings in include paths and dependencies automatically
-target_link_libraries(cmdgpt PRIVATE nlohmann_json::nlohmann_json spdlog ${OPENSSL_LIBRARIES})
+add_executable(cmdgpt_tests tests/cmdgpt_tests.cpp)
+target_link_libraries(cmdgpt_tests PRIVATE cmdgpt_lib Catch2::Catch2WithMain)
+include(CTest)
+add_test(NAME cmdgpt_tests COMMAND cmdgpt_tests)
 

--- a/cmdgpt.cpp
+++ b/cmdgpt.cpp
@@ -32,36 +32,9 @@ SOFTWARE.
 #include "spdlog/spdlog.h"
 #include "spdlog/sinks/ansicolor_sink.h"
 #include "spdlog/sinks/file_sinks.h"
+#include "cmdgpt.h"
 
 using json = nlohmann::json;
-
-// The current version
-#define CMDGPT_VERSION "v0.1"  // Added this line
-
-// Preprocessor defines for constants
-#define DEFAULT_MODEL "gpt-4"
-#define DEFAULT_SYSTEM_PROMPT "You are a helpful assistant!"
-#define DEFAULT_LOG_LEVEL spdlog::level::warn
-#define AUTHORIZATION_HEADER "Authorization"
-#define CONTENT_TYPE_HEADER "Content-Type"
-#define APPLICATION_JSON "application/json"
-#define SYSTEM_ROLE "system"
-#define USER_ROLE "user"
-#define MODEL_KEY "model"
-#define MESSAGES_KEY "messages"
-#define ROLE_KEY "role"
-#define CONTENT_KEY "content"
-#define CHOICES_KEY "choices"
-#define FINISH_REASON_KEY "finish_reason"
-#define URL "/v1/chat/completions"
-#define SERVER_URL "https://api.openai.com"
-#define EMPTY_RESPONSE_CODE -1
-#define HTTP_OK 200
-#define HTTP_BAD_REQUEST 400
-#define HTTP_UNAUTHORIZED 401
-#define HTTP_FORBIDDEN 403
-#define HTTP_NOT_FOUND 404
-#define HTTP_INTERNAL_SERVER_ERROR 500
 
 // Map of string log levels to spdlog::level::level_enum values
 const std::map<std::string, spdlog::level::level_enum> log_levels = {
@@ -204,77 +177,4 @@ int get_gpt_chat_response(const std::string& prompt, std::string& response, cons
     }
 
     return res->status;
-}
-
-/**
- * @brief The main function of the application.
- * @param argc The number of command-line arguments.
- * @param argv The command-line arguments.
- * @return The exit code of the application.
- */
-int main(int argc, char* argv[]) {
-    std::string api_key;
-    std::string system_prompt;
-    std::string gpt_model;
-    std::string log_file;
-    spdlog::level::level_enum log_level;
-    std::string prompt;
-    std::string response;
-    int status_code;
-
-    // Parse environment variables
-    api_key = getenv("OPENAI_API_KEY") ? getenv("OPENAI_API_KEY") : "";
-    system_prompt = getenv("OPENAI_SYS_PROMPT") ? getenv("OPENAI_SYS_PROMPT") : DEFAULT_SYSTEM_PROMPT;
-    gpt_model = getenv("OPENAI_GPT_MODEL") ? getenv("OPENAI_GPT_MODEL") : DEFAULT_MODEL;
-    log_file = getenv("CMDGPT_LOG_FILE") ? getenv("CMDGPT_LOG_FILE") : "logfile.txt"; // Default log file
-    std::string env_log_level = getenv("CMDGPT_LOG_LEVEL") ? getenv("CMDGPT_LOG_LEVEL") : "WARN"; // Default log level
-    log_level = log_levels.count(env_log_level) ? log_levels.at(env_log_level) : DEFAULT_LOG_LEVEL;
-
-    // Parsing command-line arguments
-    for (int i = 1; i < argc; ++i) {
-        std::string arg = argv[i];
-        if (arg == "-h" || arg == "--help") {
-            print_help();
-            return EXIT_SUCCESS;
-        } else if (arg == "-v" || arg == "--version") {  // Added this block
-            std::cout << "cmdgpt version: " << CMDGPT_VERSION << std::endl;
-            return EXIT_SUCCESS;
-        } else if (arg == "-k" || arg == "--api_key") {
-            api_key = argv[++i];
-        } else if (arg == "-s" || arg == "--sys_prompt") {
-            system_prompt = argv[++i];
-        } else if (arg == "-l" || arg == "--log_file") {
-            log_file = argv[++i];
-        } else if (arg == "-m" || arg == "--gpt_model") {
-            gpt_model = argv[++i];
-        } else if (arg == "-L" || arg == "--log_level") {
-            std::string log_level_str = argv[++i];
-            if (log_levels.count(log_level_str)) {
-                log_level = log_levels.at(log_level_str);
-            }
-        } else {
-            prompt = arg;
-        }
-    }
-
-    // Set up logging
-    auto console_sink = std::make_shared<spdlog::sinks::ansicolor_stdout_sink_mt>();
-    auto file_sink = std::make_shared<spdlog::sinks::simple_file_sink_mt>(log_file, true);
-    gLogger = std::make_shared<spdlog::logger>("multi_sink", spdlog::sinks_init_list{console_sink, file_sink});
-    gLogger->set_level(log_level);
-
-    // Make the API request and handle the response
-    if (prompt.empty()) {
-        // If no prompt was provided in the command line, read it from stdin
-        std::getline(std::cin, prompt);
-    }
-    status_code = get_gpt_chat_response(prompt, response, api_key, system_prompt, gpt_model);
-    if (status_code == EMPTY_RESPONSE_CODE) {
-        gLogger->critical("Error: Did not receive a response from the server.");
-        return 1;
-    }
-    // output the response to stdout
-    std::cout << response << std::endl;
-    // that's all folks...
-    return 0;
 }

--- a/cmdgpt.h
+++ b/cmdgpt.h
@@ -1,0 +1,45 @@
+#ifndef CMDGPT_H
+#define CMDGPT_H
+
+#include <string>
+#include <map>
+#include <memory>
+#include "spdlog/spdlog.h"
+
+// The current version
+#define CMDGPT_VERSION "v0.1"
+
+// Preprocessor defines for constants
+#define DEFAULT_MODEL "gpt-4"
+#define DEFAULT_SYSTEM_PROMPT "You are a helpful assistant!"
+#define DEFAULT_LOG_LEVEL spdlog::level::warn
+#define AUTHORIZATION_HEADER "Authorization"
+#define CONTENT_TYPE_HEADER "Content-Type"
+#define APPLICATION_JSON "application/json"
+#define SYSTEM_ROLE "system"
+#define USER_ROLE "user"
+#define MODEL_KEY "model"
+#define MESSAGES_KEY "messages"
+#define ROLE_KEY "role"
+#define CONTENT_KEY "content"
+#define CHOICES_KEY "choices"
+#define FINISH_REASON_KEY "finish_reason"
+#define URL "/v1/chat/completions"
+#define SERVER_URL "https://api.openai.com"
+#define EMPTY_RESPONSE_CODE -1
+#define HTTP_OK 200
+#define HTTP_BAD_REQUEST 400
+#define HTTP_UNAUTHORIZED 401
+#define HTTP_FORBIDDEN 403
+#define HTTP_NOT_FOUND 404
+#define HTTP_INTERNAL_SERVER_ERROR 500
+
+extern std::shared_ptr<spdlog::logger> gLogger;
+
+int get_gpt_chat_response(const std::string& prompt,
+                          std::string& response,
+                          const std::string& api_key = "",
+                          const std::string& system_prompt = "",
+                          const std::string& model = DEFAULT_MODEL);
+
+#endif // CMDGPT_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,82 @@
+#include <iostream>
+#include <string>
+#include <stdexcept>
+#include <cstdlib>
+#include <fstream>
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/ansicolor_sink.h"
+#include "spdlog/sinks/file_sinks.h"
+#include "cmdgpt.h"
+
+int main(int argc, char* argv[]) {
+    std::string api_key;
+    std::string system_prompt;
+    std::string gpt_model;
+    std::string log_file;
+    spdlog::level::level_enum log_level;
+    std::string prompt;
+    std::string response;
+    int status_code;
+
+    // Parse environment variables
+    api_key = getenv("OPENAI_API_KEY") ? getenv("OPENAI_API_KEY") : "";
+    system_prompt = getenv("OPENAI_SYS_PROMPT") ? getenv("OPENAI_SYS_PROMPT") : DEFAULT_SYSTEM_PROMPT;
+    gpt_model = getenv("OPENAI_GPT_MODEL") ? getenv("OPENAI_GPT_MODEL") : DEFAULT_MODEL;
+    log_file = getenv("CMDGPT_LOG_FILE") ? getenv("CMDGPT_LOG_FILE") : "logfile.txt"; // Default log file
+    std::string env_log_level = getenv("CMDGPT_LOG_LEVEL") ? getenv("CMDGPT_LOG_LEVEL") : "WARN"; // Default log level
+    static const std::map<std::string, spdlog::level::level_enum> log_levels = {
+        {"TRACE", spdlog::level::trace},
+        {"DEBUG", spdlog::level::debug},
+        {"INFO", spdlog::level::info},
+        {"WARN", spdlog::level::warn},
+        {"ERROR", spdlog::level::err},
+        {"CRITICAL", spdlog::level::critical},
+    };
+    log_level = log_levels.count(env_log_level) ? log_levels.at(env_log_level) : DEFAULT_LOG_LEVEL;
+
+    // Parsing command-line arguments
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
+            print_help();
+            return EXIT_SUCCESS;
+        } else if (arg == "-v" || arg == "--version") {
+            std::cout << "cmdgpt version: " << CMDGPT_VERSION << std::endl;
+            return EXIT_SUCCESS;
+        } else if (arg == "-k" || arg == "--api_key") {
+            api_key = argv[++i];
+        } else if (arg == "-s" || arg == "--sys_prompt") {
+            system_prompt = argv[++i];
+        } else if (arg == "-l" || arg == "--log_file") {
+            log_file = argv[++i];
+        } else if (arg == "-m" || arg == "--gpt_model") {
+            gpt_model = argv[++i];
+        } else if (arg == "-L" || arg == "--log_level") {
+            std::string log_level_str = argv[++i];
+            if (log_levels.count(log_level_str)) {
+                log_level = log_levels.at(log_level_str);
+            }
+        } else {
+            prompt = arg;
+        }
+    }
+
+    // Set up logging
+    auto console_sink = std::make_shared<spdlog::sinks::ansicolor_stdout_sink_mt>();
+    auto file_sink = std::make_shared<spdlog::sinks::simple_file_sink_mt>(log_file, true);
+    gLogger = std::make_shared<spdlog::logger>("multi_sink", spdlog::sinks_init_list{console_sink, file_sink});
+    gLogger->set_level(log_level);
+
+    // Make the API request and handle the response
+    if (prompt.empty()) {
+        std::getline(std::cin, prompt);
+    }
+    status_code = get_gpt_chat_response(prompt, response, api_key, system_prompt, gpt_model);
+    if (status_code == EMPTY_RESPONSE_CODE) {
+        gLogger->critical("Error: Did not receive a response from the server.");
+        return 1;
+    }
+    std::cout << response << std::endl;
+    return 0;
+}
+

--- a/tests/cmdgpt_tests.cpp
+++ b/tests/cmdgpt_tests.cpp
@@ -1,0 +1,13 @@
+#include <catch2/catch.hpp>
+#include "cmdgpt.h"
+
+TEST_CASE("Constants are defined correctly") {
+    REQUIRE(std::string(DEFAULT_MODEL) == "gpt-4");
+    REQUIRE(HTTP_OK == 200);
+}
+
+TEST_CASE("get_gpt_chat_response throws when API key missing") {
+    std::string response;
+    REQUIRE_THROWS_AS(get_gpt_chat_response("hi", response, "", ""), std::invalid_argument);
+}
+


### PR DESCRIPTION
## Summary
- add `cmdgpt.h` header exposing constants and `get_gpt_chat_response`
- split main routine into `main.cpp`
- convert project to a static library and update CMake
- add Catch2-based tests using the new header

## Testing
- `cmake ..` *(fails: Failed to clone repository 'https://github.com/yhirose/cpp-httplib.git')*
- `ctest --output-on-failure` *(no tests were found)*
